### PR TITLE
Correção teste BankAccountOwnershipValidation

### DIFF
--- a/src/modules/bank-accounts/validation/bank-account-ownership.service.spec.ts
+++ b/src/modules/bank-accounts/validation/bank-account-ownership.service.spec.ts
@@ -1,4 +1,4 @@
-import { UnauthorizedException } from "@nestjs/common";
+import { NotFoundException } from "@nestjs/common";
 import { BankAccountsRepository } from "../../../shared/database/repositories/bank-accounts.repositories";
 import { BankAccountOwnerShipValidation } from "./bank-account-ownership.service";
 import { Test } from "@nestjs/testing";
@@ -50,10 +50,10 @@ describe("Suite Test BankAccountOwnershipValidation", () => {
             expect(bankAccountsRepository.findFirst).toHaveBeenCalledWith({
                 where: { id: bankAccountId, userId },
             });
-            expect(validation.validate(userId, bankAccountId)).resolves.not.toThrow(UnauthorizedException);
+            expect(validation.validate(userId, bankAccountId)).resolves.not.toThrow(NotFoundException);
         });
 
-        it("Should throw UnauthorizedException, bank account not found", async () => {
+        it("Should throw NotFoundException, bank account not found", async () => {
             // Arrange
             const userId = "user-id";
             const bankAccountId = "bank-account-id";
@@ -62,7 +62,7 @@ describe("Suite Test BankAccountOwnershipValidation", () => {
 
             // Act & Assert
             const validationPromise = validation.validate(userId, bankAccountId);
-            await expect(validationPromise).rejects.toThrow(UnauthorizedException);
+            await expect(validationPromise).rejects.toThrow(NotFoundException);
             await expect(validationPromise).rejects.toThrow('Bank account not found.');
             
             expect(mockBankAccountsRepository.findFirst).toHaveBeenCalledWith({


### PR DESCRIPTION
Esta pull request atualiza a suíte de testes do serviço de validação de propriedade de conta bancária (`BankAccountOwnershipValidation`) para esperar uma NotFoundException em vez de uma UnauthorizedException quando uma conta bancária não é encontrada. Isso alinha as expectativas dos testes com o tratamento de erros pretendido no serviço.

Atualização no Tratamento de Exceções nos Testes:

Alterados os imports e as asserções dos testes para utilizar NotFoundException em vez de UnauthorizedException no arquivo bank-account-ownership.service.spec.ts.